### PR TITLE
use cli arg for max tasks per child for celery

### DIFF
--- a/start-production.sh
+++ b/start-production.sh
@@ -6,7 +6,7 @@ python manage.py migrate
 python manage.py collectstatic --noinput
 
 #Celery detached background processes
-celery --app=topranks worker --loglevel=info --detach --queues celery,express --concurrency=30
+celery --app=topranks worker --loglevel=info --detach --queues celery,express --concurrency=30  --max-tasks-per-child 10
 
 #Gunicorn web server
 gunicorn topranks.wsgi -b 0.0.0.0:80 --worker-tmp-dir /dev/shm --workers=2 --threads=4 --worker-class=gthread


### PR DESCRIPTION
It is possible the settings.py setting isn't working for some reason. I want to double check using the cli arg to confirm. It is also possible this setting just isn't addressing our problem here. I didn't touch the express script either so if this works we can add this to that as well.